### PR TITLE
Add Priscila Moreira as second creator of ChemoPADPLStraining2026_Annotated v1.0

### DIFF
--- a/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/README.md
+++ b/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/README.md
@@ -101,7 +101,11 @@ datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/
 
 If you use this dataset, please cite:
 
-> Wilfinger, M., Mike, M., Sweet, C. *Annotated ChemoPAD NN Training Dataset, v1.0.* Lieberman Lab, University of Notre Dame. <https://github.com/PaperAnalyticalDeviceND/annotated_chemopad>
+> Wilfinger, M., Moreira, P., Mike, M., Sweet, C. *Annotated ChemoPAD NN Training Dataset, v1.0.* Lieberman Lab, University of Notre Dame. <https://github.com/PaperAnalyticalDeviceND/annotated_chemopad>
+
+### Annotation tool
+
+The hand-annotation pass was carried out using **Priscila Moreira's PAD annotation web tool**: source at [github.com/psaboia/chemo-pad-annotations](https://github.com/psaboia/chemo-pad-annotations), deployed instance at <http://pad-annotation.crc.nd.edu:8080>. The tool's controlled vocabulary is what defines the `lighting`, `background`, `status`, `missing_card`, and `camera_bucket` value sets in the metadata CSVs above. See the source-repo wiki page [`Annotation-Process`](https://github.com/PaperAnalyticalDeviceND/annotated_chemopad/wiki/Annotation-Process) for the per-card workflow.
 
 ### License
 

--- a/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/croissant.jsonld
+++ b/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/croissant.jsonld
@@ -46,7 +46,7 @@
   "license": "https://www.apache.org/licenses/LICENSE-2.0",
   "creator": {
     "@type": "schema:Person",
-    "name": "Wilfinger, Mike, Sweet (Lieberman Lab, University of Notre Dame)",
+    "name": "Wilfinger, Moreira, Mike, Sweet (Lieberman Lab, University of Notre Dame)",
     "url": "https://github.com/PaperAnalyticalDeviceND"
   },
   "publisher": {


### PR DESCRIPTION
## Summary

Updates `Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0` (merged in #4) to credit Priscila Moreira as the second creator.

She authored the [PAD annotation web tool](https://github.com/psaboia/chemo-pad-annotations) (deployed at <http://pad-annotation.crc.nd.edu:8080>) that Maximilian Wilfinger used to enter the `lighting`, `background`, `status`, `missing_card`, and `camera_bucket` annotations that distinguish this release from the prior `Partial-Drug-Set v1.0` entry. The tool's UI defines the controlled vocabulary for those fields, so it is the canonical reference for how the annotation columns should be interpreted.

## Changes

- `croissant.jsonld`: `creator.name` now reads "Wilfinger, Moreira, Mike, Sweet (Lieberman Lab, University of Notre Dame)".
- `README.md`: citation updated to four authors; new "Annotation tool" section pointing at the tool's source repo, the deployed instance, and the source-repo wiki page `Annotation-Process` for the workflow detail.

No data file changes (the metadata CSVs, labels.csv, projects.csv, class_distribution.csv, dataset_sizes.md, and figs/ directory are untouched).

## Local validation

`docs/_scripts/validate_croissant.py` passes for all 11 entries including the modified one.

## Test plan

- [ ] Build-and-deploy workflow runs on push to main
- [ ] Catalog page at <https://padproject.info/pad_dataset_registry/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/> shows the new four-author citation and the Annotation tool section