### PR TITLE
Update annotation tool URL to PaperAnalyticalDeviceND/chemo-pad-annotations

### DIFF
--- a/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/README.md
+++ b/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/README.md
@@ -105,7 +105,7 @@ If you use this dataset, please cite:
 
 ### Annotation tool
 
-The hand-annotation pass was carried out using **Priscila Moreira's PAD annotation web tool**: source at [github.com/psaboia/chemo-pad-annotations](https://github.com/psaboia/chemo-pad-annotations), deployed instance at <http://pad-annotation.crc.nd.edu:8080>. The tool's controlled vocabulary is what defines the `lighting`, `background`, `status`, `missing_card`, and `camera_bucket` value sets in the metadata CSVs above. See the source-repo wiki page [`Annotation-Process`](https://github.com/PaperAnalyticalDeviceND/annotated_chemopad/wiki/Annotation-Process) for the per-card workflow.
+The hand-annotation pass was carried out using **Priscila Moreira's PAD annotation web tool**: source at [github.com/PaperAnalyticalDeviceND/chemo-pad-annotations](https://github.com/PaperAnalyticalDeviceND/chemo-pad-annotations), deployed instance at <http://pad-annotation.crc.nd.edu:8080>. The tool's controlled vocabulary is what defines the `lighting`, `background`, `status`, `missing_card`, and `camera_bucket` value sets in the metadata CSVs above. See the source-repo wiki page [`Annotation-Process`](https://github.com/PaperAnalyticalDeviceND/annotated_chemopad/wiki/Annotation-Process) for the per-card workflow.
 
 ### License
 


### PR DESCRIPTION
## Summary

Priscila moved her chemo-pad-annotations repository from her personal GitHub account to the project organization. This PR updates the corresponding URL in the `Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0` catalog page's "Annotation tool" section so the link on padproject.info doesn't 404.

## Change

Single-line edit in `datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/README.md`:

- `github.com/psaboia/chemo-pad-annotations` → `github.com/PaperAnalyticalDeviceND/chemo-pad-annotations`

Deployed instance at `pad-annotation.crc.nd.edu:8080` is unchanged. No metadata, croissant, schema, or class-distribution changes.

## Test plan

- [ ] Build-and-deploy workflow runs on push to main.
- [ ] Catalog page at <https://padproject.info/pad_dataset_registry/datasets/Leiberman-Lab_ChemoPADPLStraining2026_Annotated_v1.0/> renders the new URL and the link resolves to the org-hosted repo.